### PR TITLE
Bugfix: fixed crash caused by gradients.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2025.6.25.1 -- Bugfix: fixed crash caused by gradients.
+    * The addition of the gradients to the atom data caused a crash when expanding the
+      cell. Since it doesn't obviously make sense to expand the gradients, they are
+      ignored when building a supercell.
+
 2025.6.25 -- Bugfix: avoid lowering symmetry for P1 systems.
 
 2023.11.5 -- Updated to handle symmetry in systems

--- a/supercell_step/supercell.py
+++ b/supercell_step/supercell.py
@@ -159,6 +159,12 @@ class Supercell(seamm.Node):
         bond_data = bonds.get_as_dict()
         del bond_data["id"]
 
+        # Remove the gradients, if they exist
+        if "gx" in atom_data:
+            del atom_data["gx"]
+            del atom_data["gy"]
+            del atom_data["gz"]
+
         # Get the initial fractional coordinates, adjusting to the final cell
         xyz0 = [
             [x / na, y / nb, z / nc]
@@ -187,6 +193,12 @@ class Supercell(seamm.Node):
             bond_data = bonds.get_as_dict()
             del bond_data["id"]
 
+            # Remove the gradients, if they exist
+            if "gx" in atom_data:
+                del atom_data["gx"]
+                del atom_data["gy"]
+                del atom_data["gz"]
+
             # Keep a copy of the current coordinates
             xyz0 = list(xyzs)
 
@@ -210,6 +222,12 @@ class Supercell(seamm.Node):
             del atom_data["id"]
             bond_data = bonds.get_as_dict()
             del bond_data["id"]
+
+            # Remove the gradients, if they exist
+            if "gx" in atom_data:
+                del atom_data["gx"]
+                del atom_data["gy"]
+                del atom_data["gz"]
 
             # Keep a copy of the current coordinates
             xyz0 = list(xyzs)


### PR DESCRIPTION
* The addition of the gradients to the atom data caused a crash when expanding the cell. Since it doesn't obviously make sense to expand the gradients, they are ignored when building a supercell.